### PR TITLE
🚀 [Feature] #1 - JWT로그인 및 회원가입 기능 추가

### DIFF
--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthController.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthController.kt
@@ -1,0 +1,36 @@
+package com.apple.team_prometheus.domain.auth
+
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping(value = ["/auth"])
+@Tag(name = "Auth")
+class AuthController(val authService: AuthService) {
+
+    @PostMapping(value = ["/login"])
+    fun login(
+        @RequestBody loginDto: AuthLoginDto.Request
+    ): ResponseEntity<AuthLoginDto.Response> {
+
+        return ResponseEntity.ok(
+            authService.userLogin(loginDto)
+        )
+    }
+
+    @PostMapping(value = ["/join"])
+    fun join(
+        @RequestBody joinDto: AuthJoinDto.Request
+    ): ResponseEntity<AuthJoinDto.Response> {
+
+        return  ResponseEntity.ok(
+            authService.userJoin(joinDto)
+        )
+    }
+
+}

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthJoinDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthJoinDto.kt
@@ -1,0 +1,17 @@
+package com.apple.team_prometheus.domain.auth
+
+class AuthJoinDto {
+
+    class Response(val id:Long, var password: String)
+
+
+    class Request {
+        val id: Long = 0
+
+        var password: String = ""
+
+        var name: String = ""
+
+        var roomNum: Int = 0
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
@@ -1,0 +1,18 @@
+package com.apple.team_prometheus.domain.auth
+
+import com.apple.team_prometheus.global.jwt.AccessToken
+
+
+class AuthLoginDto {
+
+    data class Response(
+        var id: Long,
+        var token: AccessToken.Response
+    )
+
+    class Request {
+        val id: Long = 0
+
+        var password: String = ""
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthRepository.kt
@@ -1,0 +1,14 @@
+package com.apple.team_prometheus.domain.auth
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+
+@Repository
+interface AuthRepository : JpaRepository<AuthUser?, Long?> {
+    override fun findById(id: Long): Optional<AuthUser?>
+
+    override fun existsById(id: Long): Boolean
+
+}

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthService.kt
@@ -1,0 +1,90 @@
+package com.apple.team_prometheus.domain.auth
+
+import com.apple.team_prometheus.global.exception.Exceptions
+import com.apple.team_prometheus.global.exception.ErrorCode
+import com.apple.team_prometheus.global.jwt.*
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+
+
+@Service
+class AuthService(
+    private val authRepository: AuthRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtProperties: JwtProperties,
+    private val jwtProvider: TokenProvider,
+    private val jwtRepository: JwtRepository) {
+
+
+    fun userJoin(joinDto: AuthJoinDto.Request): AuthJoinDto.Response {
+
+        if(authRepository.existsById(joinDto.id)) {
+            throw Exceptions(ErrorCode.DUPLICATED_ID)
+        }
+
+        val newUser: AuthUser = AuthUser(
+            joinDto.id,
+            joinDto.password,
+            joinDto.name,
+            joinDto.roomNum
+        )
+        newUser.password = passwordEncoder.encode(newUser.password)
+        val save: AuthUser = authRepository.save(newUser)
+
+        val response: AuthJoinDto.Response = AuthJoinDto.Response(save.id, save.password)
+
+        return response
+    }
+
+
+    @Transactional
+    fun userLogin(loginDto: AuthLoginDto.Request): AuthLoginDto.Response {
+
+        val user: AuthUser? = authRepository.findById(loginDto.id)
+            .orElseThrow {
+                Exceptions(ErrorCode.USER_NOT_FOUND)
+            }
+
+        if (!passwordEncoder.matches(loginDto.password, user!!.password)) {
+            throw Exceptions(ErrorCode.INVALID_PASSWORD)
+        }
+
+
+
+        val token: AccessToken.Response = createAccessToken(user, null)
+
+        val response: AuthLoginDto.Response = AuthLoginDto.Response(user.id, token)
+        return response
+    }
+
+
+    private fun createAccessToken(user: AuthUser, refreshToken: String?): AccessToken.Response {
+        val tokenDuration: Duration = Duration.ofMinutes(jwtProperties.duration)
+        val refreshDuration: Duration = Duration.ofMinutes(jwtProperties.refreshDuration.toLong())
+
+        var savedRefreshToken: RefreshToken? = jwtRepository.findById(user.id)
+            .orElse(null)
+
+        if (savedRefreshToken != null && refreshToken != null) {
+            if (!savedRefreshToken.getRefreshToken().equals(refreshToken)) return AccessToken.Response(
+                "Invalid token.",
+                null,
+                null
+            )
+        }
+
+        val accessToken = jwtProvider.generateToken(user, tokenDuration, true)
+        val newRefreshToken = jwtProvider.generateToken(user, refreshDuration, false)
+
+        if (savedRefreshToken == null) {
+            savedRefreshToken = RefreshToken(user.id, newRefreshToken)
+        } else {
+            savedRefreshToken.setRefreshToken(newRefreshToken)
+        }
+
+        jwtRepository.save(savedRefreshToken)
+        return AccessToken.Response("ok", accessToken, newRefreshToken)
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
@@ -1,0 +1,20 @@
+package com.apple.team_prometheus.domain.auth
+
+import jakarta.persistence.*
+
+@Entity
+data class AuthUser(
+    @Id
+    @Column(nullable = false)
+    val id: Long,
+
+    @Column(nullable = false)
+    var password: String,
+
+    @Column(nullable = false)
+    var name: String,
+
+    @Column(nullable = false)
+    var roomNum: Int
+
+)

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/Role.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/Role.kt
@@ -1,0 +1,11 @@
+package com.apple.team_prometheus.domain.auth
+
+enum class Role {
+    STUDENT,
+    TEACHER;
+
+
+    fun getAuthority() {
+
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/notification/Notification.kt
@@ -1,0 +1,18 @@
+package com.apple.team_prometheus.domain.notification
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+data class Notification (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+    @Column(nullable = false)
+    var title: String,
+    @Column(nullable = false)
+    var detail: String
+)

--- a/src/main/kotlin/com/apple/team_prometheus/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/exception/ErrorCode.kt
@@ -1,0 +1,26 @@
+package com.apple.team_prometheus.global.exception
+
+import org.springframework.http.HttpStatus
+
+
+enum class ErrorCode(val httpStatus: HttpStatus, val errorMessage: String) {
+    // Status 400
+    INVALID_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "잘못된 요청값"),
+
+    // Status 401
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰값"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "틀린 비밀번호"),
+
+    // Status 403
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한 없음!"),
+
+    // Status 404
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없음"),
+
+    // Status 409
+    DUPLICATED_ID(HttpStatus.CONFLICT, "이미 사용중인 아이디"),
+
+    // Status 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류")
+
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/exception/Exceptions.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/exception/Exceptions.kt
@@ -1,0 +1,8 @@
+package com.apple.team_prometheus.global.exception
+
+import com.apple.team_prometheus.global.exception.ErrorCode
+
+
+class Exceptions(errorCode: ErrorCode) : RuntimeException(errorCode.errorMessage) {
+    private val errorCode: ErrorCode = errorCode
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/AccessToken.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/AccessToken.kt
@@ -1,0 +1,16 @@
+package com.apple.team_prometheus.global.jwt
+
+class AccessToken {
+
+    data class Response (
+        val result: String,
+        val token: String?,
+        val refreshToken: String?
+    )
+
+
+    data class Request (
+        var id: Long? = null,
+        var password: String? = null
+    )
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/CreateAccessTokenByRefreshToken.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/CreateAccessTokenByRefreshToken.kt
@@ -1,0 +1,5 @@
+package com.apple.team_prometheus.global.jwt
+
+class CreateAccessTokenByRefreshToken {
+    val refreshToken: String? = null
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/JwtProperties.kt
@@ -1,0 +1,14 @@
+package com.apple.team_prometheus.global.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+
+
+
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    var duration: Long,
+    var refreshDuration: Long,
+    var secretKey: String,
+    var issuer: String
+)

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/JwtRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/JwtRepository.kt
@@ -1,0 +1,11 @@
+package com.apple.team_prometheus.global.jwt
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+
+@Repository
+interface JwtRepository: JpaRepository<RefreshToken, Long> {
+    override fun findById(id: Long): Optional<RefreshToken>
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/RefreshToken.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/RefreshToken.kt
@@ -1,0 +1,33 @@
+package com.apple.team_prometheus.global.jwt
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+
+@Entity
+data class RefreshToken(
+    @field:Column(
+        updatable = true, nullable = false
+    ) private val userId: Long,
+
+    @field:Column(
+        nullable = false
+    ) private var refreshToken: String
+
+) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private val id: Long? = null
+
+    fun getRefreshToken(): String = refreshToken
+
+    fun setRefreshToken(newRefreshToken: String) {
+        this.refreshToken = newRefreshToken
+    }
+
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenAuthenticationFilter.kt
@@ -1,0 +1,54 @@
+package com.apple.team_prometheus.global.jwt
+
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.security.SignatureException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.io.IOException
+
+
+@Component
+class TokenAuthenticationFilter(val tokenProvider: TokenProvider) : OncePerRequestFilter() {
+
+
+    @Throws(ServletException::class, IOException::class)
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val HEADER = "Authorization"
+        val authorizationHeader = request.getHeader(HEADER)
+        val token = getAccessToken(authorizationHeader)
+
+        try {
+            if (token != null) {
+                val authentication: Authentication = tokenProvider!!.getAuthentication(token)
+                SecurityContextHolder.getContext().authentication = authentication
+            }
+            filterChain.doFilter(request, response)
+        } catch (e: IllegalArgumentException) {
+            throw JwtException("Invalid Token. 유효하지 않은 토큰")
+        } catch (e: ExpiredJwtException) {
+            throw JwtException("Expired token, 토큰 기한 만료" + e.message)
+        } catch (e: SignatureException) {
+            throw JwtException("Signature Failed. 인증실패")
+        }
+    }
+
+    private fun getAccessToken(authorizationHeader: String?): String? {
+        val PREFIX = "Bearer "
+        return if (authorizationHeader != null && authorizationHeader.startsWith(PREFIX)) {
+            authorizationHeader.substring(PREFIX.length)
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenErrorResponse.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenErrorResponse.kt
@@ -1,0 +1,5 @@
+package com.apple.team_prometheus.global.jwt
+
+data class TokenErrorResponse(val message: String?) {
+    var errorMessage: String? = null
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenExceptionFilter.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenExceptionFilter.kt
@@ -1,0 +1,41 @@
+package com.apple.team_prometheus.global.jwt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.JwtException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.io.IOException
+
+
+@Component
+class TokenExceptionFilter : OncePerRequestFilter() {
+
+    @Throws(ServletException::class, IOException::class)
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: JwtException) {
+            setErrorResponse(response, e)
+        }
+    }
+
+    @Throws(IOException::class)
+    fun setErrorResponse(response: HttpServletResponse, throwable: Throwable) {
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = "application/json; charset=UTF-8"
+
+        val jwtExceptionResponse: TokenErrorResponse = TokenErrorResponse(throwable.message)
+        val mapper = ObjectMapper()
+
+        response.writer.write(mapper.writeValueAsString(jwtExceptionResponse))
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenProvider.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenProvider.kt
@@ -1,0 +1,84 @@
+package com.apple.team_prometheus.global.jwt
+
+
+import com.apple.team_prometheus.domain.auth.AuthUser
+import io.jsonwebtoken.*
+import io.jsonwebtoken.security.Keys
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.util.*
+import javax.crypto.SecretKey
+
+@Service
+class TokenProvider(private val jwtProperties: JwtProperties) {
+    private val key: SecretKey = Keys.hmacShaKeyFor(
+        Base64.getUrlDecoder().decode(jwtProperties.secretKey)
+    )
+
+    private val parser: JwtParser = Jwts.parserBuilder()
+        .setSigningKey(key)
+        .requireIssuer(jwtProperties.issuer)
+        .setAllowedClockSkewSeconds(60)
+        .build()
+
+    fun generateToken(user: AuthUser, expiredAt: Duration, isAccessToken: Boolean): String {
+        val now = Date()
+        val expiry = Date(now.time + expiredAt.toMillis())
+
+        return Jwts.builder()
+            .setHeaderParam("typ", "JWT")
+            .setHeaderParam("alg", "HS256")
+            .setIssuer(jwtProperties.issuer)
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .setSubject(user.name)
+            .claim("type", if (isAccessToken) "Access" else "Refresh")
+            .claim("id", user.id)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun getAuthentication(token: String?): Authentication {
+        requireNotNull(token) { "Token cannot be null" }
+
+        val claims = getClaims(token)
+
+        val tokenType = claims["type"]?.toString()
+            ?: throw IllegalArgumentException("Claims에서 토큰 유형을 찾지 못하였습니다.")
+        if (tokenType != "Access") {
+            throw IllegalArgumentException("RefreshToken은 인증에 사용 할 수없습니다")
+        }
+
+        val authorities = listOf(SimpleGrantedAuthority("ROLE_USER"))
+        val userDetails = User(
+            claims.subject ?: throw IllegalArgumentException("Subject not found in token"),
+            "",
+            authorities
+        )
+
+        return UsernamePasswordAuthenticationToken(userDetails, token, authorities)
+    }
+
+    fun getClaims(token: String?): Claims {
+        try {
+            requireNotNull(token) { "Token cannot be null" }
+            return parser.parseClaimsJws(token).body
+        } catch (e: JwtException) {
+            throw IllegalArgumentException("Invalid JWT token: ${e.message}")
+        }
+    }
+
+
+    fun isValidToken(token: String?): Boolean {
+        return try {
+            getClaims(token)
+            true
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
@@ -1,0 +1,45 @@
+package com.apple.team_prometheus.global.security
+
+import com.apple.team_prometheus.global.jwt.TokenAuthenticationFilter
+import com.apple.team_prometheus.global.jwt.TokenExceptionFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.*
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
+
+
+@Configuration
+class SecurityConfig(
+    private val tokenAuthenticationFilter: TokenAuthenticationFilter,
+    private val tokenExceptionFilter: TokenExceptionFilter) {
+
+    @Bean
+    @Throws(Exception::class)
+    fun filterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
+        httpSecurity
+            .httpBasic{ it.disable() }
+            .csrf{ it.disable() }
+            .authorizeHttpRequests { auth ->
+                auth.requestMatchers(
+                    AntPathRequestMatcher("/auth/**"),
+                    AntPathRequestMatcher("/swagger-ui.html"),
+                    AntPathRequestMatcher("/swagger-ui/**"),
+                    AntPathRequestMatcher("/v3/api-docs/**")
+                ).permitAll()
+                    .anyRequest().authenticated()
+            }
+            .addFilterBefore(tokenAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(tokenExceptionFilter, TokenAuthenticationFilter::class.java)
+        return httpSecurity.build();
+    }
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder{
+        return BCryptPasswordEncoder()
+    }
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/swagger/SwaggerConfig.kt
@@ -1,0 +1,25 @@
+package com.apple.team_prometheus.global.swagger
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    //http://localhost:8080/swagger-ui/index.html
+    @Bean
+    fun customOpenAPI(): OpenAPI {
+        return OpenAPI()
+            .components(Components())
+            .info(info())
+    }
+
+    private fun info(): Info {
+        return Info()
+            .title("Mongo Basic API")
+            .description("Mongo API reference for developers")
+            .version("1.0")
+    }
+}


### PR DESCRIPTION
### **🔹 작업 내용**

- 사용자 로그인 기능을 추가했습니다.
- 아이디 및 비밀번호를 입력받아 인증 후 JWT 토큰을 반환하는 API를 구현했습니다.

### **🔍 변경 사항 상세**

- **API 추가:**
    - `POST /auth/login` 엔드포인트 구현
    - 아이디과 비밀번호를 입력하면 데이터베이스에서 확인 후 JWT 토큰 발급
    - 비밀번호는 `bcrypt`로 해싱하여 저장

### **📸 스크린샷 (UI 변경이 있을 경우)**

- 백엔드 작업이므로 해당사항 없음.

### **⚠️ 주의 사항 & 중점적으로 봐야 할 부분**

- **비밀번호 해싱이 올바르게 적용되었는지 확인 필요**
- **JWT 토큰의 만료 시간 및 Refresh Token 관리 정책 검토 필요**
- **로그인 실패 시, 적절한 에러 메시지가 반환되는지 확인 (401 Unauthorized vs 400 Bad Request 등)**
- **기존 사용자 데이터와 충돌이 발생할 가능성이 있는지 체크**

### **🔗 관련 이슈**
- #1 