### PR TITLE
🚀 [Fixes] #6 - 사용자 로그인 방식 및 Refresh 토큰 수정

### DIFF
--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Attendance.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Attendance.kt
@@ -27,5 +27,10 @@ data class Attendance (
     @Column(nullable = false)
     val status: Status
 ) {
-    constructor(): this(0L, AuthUser(), LocalDateTime.now(),Status.NOT_ATTENDING)
+    constructor(): this(
+        id = 0L,
+        user = AuthUser(),
+        checkTime = LocalDateTime.now(),
+        status = Status.NOT_ATTENDING
+    )
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceController.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceController.kt
@@ -7,12 +7,12 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 
-@RestController("/api/attendance")
+@RestController(value = "/api/attendance")
 class AttendanceController(
     private val attendanceService: AttendanceService
 ) {
 
-    @PostMapping("/check")
+    @PostMapping(value = ["/check"])
     fun checkAttendance(
         @RequestBody request: AttendanceDto.Request
     ): ResponseEntity<AttendanceDto.Response> {
@@ -22,7 +22,7 @@ class AttendanceController(
         )
     }
 
-    @GetMapping("/no-attendance")
+    @GetMapping(value = ["/no-attendance"])
     fun getNoAttendanceList(): ResponseEntity<List<NoAttendance>> {
         return ResponseEntity.ok(
             attendanceService.getNoAttendance()

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceController.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceController.kt
@@ -24,6 +24,7 @@ class AttendanceController(
 
     @GetMapping(value = ["/no-attendance"])
     fun getNoAttendanceList(): ResponseEntity<List<NoAttendance>> {
+
         return ResponseEntity.ok(
             attendanceService.getNoAttendance()
         )

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceDto.kt
@@ -2,7 +2,6 @@ package com.apple.team_prometheus.domain.attendance
 
 import com.apple.team_prometheus.domain.auth.AuthUser
 import java.time.LocalDateTime
-import java.time.Year
 
 class AttendanceDto {
 

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceDto.kt
@@ -13,7 +13,7 @@ class AttendanceDto {
     )
 
     data class Request(
-        val birthYear: Int,
+        val birth: String,
         val name: String,
         val yearOfAdmission: Int
     )

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceRepository.kt
@@ -3,7 +3,6 @@ package com.apple.team_prometheus.domain.attendance
 import com.apple.team_prometheus.domain.auth.AuthUser
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import java.time.LocalDateTime
 
 
 @Repository

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceService.kt
@@ -8,6 +8,8 @@ import com.apple.team_prometheus.global.exception.Exceptions
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Year
 
@@ -23,10 +25,9 @@ class AttendanceService(
     }
 
     fun checkAttendance(request: AttendanceDto.Request): AttendanceDto.Response {
-        val user = authRepository.findByBirthYearAndNameAndYearOfAdmission(
-            birthYear = Year.of(request.birthYear),
-            name = request.name,
-            yearOfAdmission = Year.of(request.yearOfAdmission)
+        val user = authRepository.findByBirthYearAndName(
+            birth = LocalDate.parse(request.birth),
+            name = request.name
         ).orElseThrow {
             Exceptions(ErrorCode.USER_NOT_FOUND)
         } ?: throw IllegalStateException("유저가 null입니다.")
@@ -54,19 +55,23 @@ class AttendanceService(
     }
 
     @Scheduled(cron = "\${schedule.cron.morning}")
+    @Transactional
     fun resetMorningAttendance() {
         closeAttendance()
     }
 
     @Scheduled(cron = "\${schedule.cron.lunch}")
+    @Transactional
     fun resetLunchAttendance() {
         closeAttendance()
     }
 
     @Scheduled(cron = "\${schedule.cron.evening}")
+    @Transactional
     fun resetEveningAttendance() {
         closeAttendance()
     }
+
 
     private fun closeAttendance() {
         val students = authRepository.findAll().filter {

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/AttendanceService.kt
@@ -1,17 +1,15 @@
 package com.apple.team_prometheus.domain.attendance
 
 import com.apple.team_prometheus.domain.auth.AuthRepository
-import com.apple.team_prometheus.domain.auth.AuthUser
 import com.apple.team_prometheus.domain.auth.Role
 import com.apple.team_prometheus.global.exception.ErrorCode
 import com.apple.team_prometheus.global.exception.Exceptions
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.Year
+
 
 @Service
 class AttendanceService(
@@ -29,7 +27,9 @@ class AttendanceService(
             birth = LocalDate.parse(request.birth),
             name = request.name
         ).orElseThrow {
-            Exceptions(ErrorCode.USER_NOT_FOUND)
+            Exceptions(
+                ErrorCode.USER_NOT_FOUND
+            )
         } ?: throw IllegalStateException("유저가 null입니다.")
 
         val now = LocalDateTime.now()

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthJoinDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthJoinDto.kt
@@ -4,9 +4,9 @@ class AuthJoinDto {
 
     data class Response(
 
-        val id:Long,
+        val name: String,
 
-        val password: String
+        val status: String
     )
 
 

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthJoinDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthJoinDto.kt
@@ -3,22 +3,23 @@ package com.apple.team_prometheus.domain.auth
 class AuthJoinDto {
 
     data class Response(
+
         val id:Long,
+
         val password: String
     )
 
 
     data class Request (
-        val LoginId: Long = 0,
 
-        var password: String = "",
+        var name: String,
 
-        var name: String = "",
+        var password: String,
 
-        var roomNum: Int = 0,
+        var roomNum: Int,
 
-        val birthYear: Int = 0,
+        val birth: String,
 
-        var yearOfAdmission: Int = 0
+        var yearOfAdmission: Int
     )
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
@@ -10,9 +10,9 @@ class AuthLoginDto {
         var token: AccessToken.Response
     )
 
-    class Request {
-        val id: Long = 0
-
-        var password: String = ""
-    }
+    data class Request (
+        var name: String,
+        var birth: String,
+        var password: String,
+    )
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthRepository.kt
@@ -1,8 +1,10 @@
 package com.apple.team_prometheus.domain.auth
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
-import java.time.Year
+import java.time.LocalDate
 import java.util.*
 
 
@@ -14,9 +16,10 @@ interface AuthRepository : JpaRepository<AuthUser?, Long?> {
 
     override fun existsById(id: Long): Boolean
 
-    fun findByBirthYearAndNameAndYearOfAdmission(
-        birthYear: Year,
-        name: String,
-        yearOfAdmission: Year
+    @Query("SELECT u FROM users u " +
+            "WHERE u.birth = :birth AND u.name = :name")
+    fun findByBirthYearAndName(
+        @Param("birth") birth: LocalDate,
+        @Param("name") name: String
     ): Optional<AuthUser>
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthService.kt
@@ -54,12 +54,19 @@ class AuthService(
     ): AuthLoginDto.Response {
 
         val user = authRepository.findByBirthYearAndName(
-            birth = LocalDate.parse(loginDto.birth, DateTimeFormatter.ofPattern("yyyy/MM/dd")),
+            birth = LocalDate.parse(
+                loginDto.birth,
+                DateTimeFormatter.ofPattern("yyyy/MM/dd")
+            ),
             name = loginDto.name
-        ).orElseThrow { Exceptions(errorCode = ErrorCode.USER_NOT_FOUND) }
+        ).orElseThrow {
+            Exceptions(errorCode = ErrorCode.USER_NOT_FOUND)
+        }
 
         if (!passwordEncoder.matches(loginDto.password, user!!.password)) {
-            throw Exceptions(errorCode = ErrorCode.INVALID_PASSWORD)
+            throw Exceptions(
+                errorCode = ErrorCode.INVALID_PASSWORD
+            )
         }
 
         val token = createAccessToken(user)
@@ -82,7 +89,10 @@ class AuthService(
             refreshToken = refreshToken
         ))
 
-        return AccessToken.Response("ok", accessToken, refreshToken)
+        return AccessToken.Response(
+            result = "ok",
+            token = accessToken,
+            refreshToken = refreshToken)
     }
 
     // 리프레시 토큰으로 액세스 토큰 갱신 (회전 적용)
@@ -131,7 +141,11 @@ class AuthService(
                 refreshToken = newRefreshToken
             ))
 
-            return AccessToken.Response("ok", newAccessToken, newRefreshToken)
+            return AccessToken.Response(
+                result = "ok",
+                token = newAccessToken,
+                refreshToken = newRefreshToken
+            )
         } catch (e: ExpiredJwtException) {
             return AccessToken.Response("Expired refresh token", null, null)
         } catch (e: Exceptions) {

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
@@ -2,7 +2,9 @@ package com.apple.team_prometheus.domain.auth
 
 import com.apple.team_prometheus.domain.attendance.Attendance
 import com.apple.team_prometheus.domain.attendance.NoAttendance
+import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
+import java.time.LocalDate
 import java.time.Year
 
 @Entity(name = "users")
@@ -20,12 +22,10 @@ data class AuthUser(
     val id: Long = 0L,
 
     @Column(nullable = false)
-    val loginId: Long,
-
-    @Column(nullable = false)
+    @JsonIgnore
     var password: String,
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "name")
     var name: String,
 
     @Column(nullable = false)
@@ -34,14 +34,14 @@ data class AuthUser(
     @Column(nullable = false)
     val role: Role,
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.EAGER)
     var attendance: List<Attendance>,
 
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.EAGER)
     var noAttendance: List<NoAttendance>,
 
-    @Column(nullable = false)
-    var birthYear: Year,
+    @Column(nullable = false, name = "birth_year")
+    var birth: LocalDate,
 
     @Column(nullable = false)
     val yearOfAdmission: Year,
@@ -52,6 +52,16 @@ data class AuthUser(
 
 
 ) {
-    constructor() : this(0L, 0L, "", "", 0, Role.STUDENT, emptyList(), emptyList(),Year.now(), Year.now(), false)
+    constructor() : this(
+        password = "",
+        name = "",
+        roomNum = 0,
+        role = Role.STUDENT,
+        attendance = emptyList(),
+        noAttendance = emptyList(),
+        birth = LocalDate.now(),
+        yearOfAdmission = Year.now(),
+        isGraduate = false
+    )
 
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/notification/Notification.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/notification/Notification.kt
@@ -15,4 +15,10 @@ data class Notification (
     var title: String,
     @Column(nullable = false)
     var detail: String
-)
+) {
+    constructor() : this(
+        id = 0L,
+        title = "",
+        detail = ""
+    )
+}

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/JwtRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/JwtRepository.kt
@@ -2,7 +2,7 @@ package com.apple.team_prometheus.global.jwt
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import java.util.*
+
 
 
 @Repository

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/RefreshToken.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/RefreshToken.kt
@@ -2,8 +2,6 @@ package com.apple.team_prometheus.global.jwt
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
 

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/RefreshToken.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/RefreshToken.kt
@@ -9,28 +9,10 @@ import jakarta.persistence.Id
 
 @Entity
 data class RefreshToken(
-    @field:Column(
-        updatable = true, nullable = false
-    ) private val userId: Long,
-
-    @field:Column(
-        nullable = false
-    ) private var refreshToken: String
-
-) {
-
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(updatable = false)
-    private val id: Long? = null
-
-    fun getRefreshToken(): String = refreshToken
-
-    fun setRefreshToken(newRefreshToken: String) {
-        this.refreshToken = newRefreshToken
-    }
-
+    val userId: Long,
+    @Column(nullable = false, length = 1000)
+    val refreshToken: String
+) {
     constructor() : this(0L, "")
-
 }

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenAuthenticationFilter.kt
@@ -15,7 +15,10 @@ import java.io.IOException
 
 
 @Component
-class TokenAuthenticationFilter(val tokenProvider: TokenProvider) : OncePerRequestFilter() {
+class TokenAuthenticationFilter(
+    private val tokenProvider: TokenProvider
+) : OncePerRequestFilter() {
+
     @Throws(ServletException::class, IOException::class)
     override fun doFilterInternal(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
@@ -30,13 +30,9 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
 
                 auth
-                    .requestMatchers("/api/check-in/**").access { _, request ->
-                        val remoteAddr = (request as HttpServletRequest).remoteAddr
-                        val allowedIp = "172.16.1.250"
-                        AuthorizationDecision(remoteAddr == allowedIp)
-                    }
-                    .requestMatchers("/auth/join").hasRole("TEACHER")
+                    //.requestMatchers("/auth/join").hasRole("TEACHER")
                     .requestMatchers(
+                        AntPathRequestMatcher("/auth/join"),
                         AntPathRequestMatcher("/auth/login"),
                         AntPathRequestMatcher("/auth/login/token"),
                         AntPathRequestMatcher("/swagger-ui.html"),

--- a/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
@@ -2,10 +2,8 @@ package com.apple.team_prometheus.global.security
 
 import com.apple.team_prometheus.global.jwt.TokenAuthenticationFilter
 import com.apple.team_prometheus.global.jwt.TokenExceptionFilter
-import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.authorization.AuthorizationDecision
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configurers.*
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
@@ -13,7 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
-import java.net.InetAddress
+
 
 
 @Configuration


### PR DESCRIPTION
### **🔹 작업 내용**

- 기존의 학번으로 로그인 하는 방식이 아닌 이름과 생년월일을 사용하여 로그인 하는 방식으로 교체 하였습니다
- RefreshToken으로 토큰을 여러번 재발급 받던 로직을 수정하였습니다.

### **🔍 변경 사항 상세**
- **기존 방식 vs 변경 후 방식:**
    - 기존에는 학번으로 로그인을 하였으나, 이 방식은 매년 수정해야 하기 때문에 이름과 생년월일로 복합 유니크키를 생성하여서 매년 수정할 필요가 없도록 만들었습니다.
    - `refresh token`한개로 AccessToken을 여러번 발급 받을 수 있었던 로직을 한번만 발급이 되도록 수정하였습니다.

### **📸 스크린샷 (UI 변경이 있을 경우)**

- 백엔드 작업이므로 해당사항 없음.

### **⚠️ 주의 사항 & 중점적으로 봐야 할 부분**

- **토큰이 올바르게 잘 발급되는지 확인 필요**
- **로그인 방식에서 문제가 생기지 않는지 확인 필요**
- **로그인 및 토큰 발급 실패 시, 적절한 에러 메시지가 반환되는지 확인 (401 Unauthorized vs 400 Bad Request 등)**

### **🔗 관련 이슈**

- **Fixes** #10 
- **Related** #11  