### PR TITLE
🚀 [Fix] #42 - 커스텀 에러로 바꾸고, RefreshToken이 만료 시 삭제

### DIFF
--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Attendance.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Attendance.kt
@@ -1,13 +1,7 @@
 package com.apple.team_prometheus.domain.attendance
 
 import com.apple.team_prometheus.domain.auth.AuthUser
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.OneToOne
+import jakarta.persistence.*
 import java.time.LocalDateTime
 
 
@@ -17,7 +11,7 @@ data class Attendance(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "users_id", nullable = false)
     val user: AuthUser?,
 

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Attendance.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Attendance.kt
@@ -7,22 +7,21 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
 import java.time.LocalDateTime
 
 
 @Entity
-data class Attendance (
+data class Attendance(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
+    val id: Long = 0L,
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "users_id", nullable = false)
-    val user: AuthUser,
+    val user: AuthUser?,
 
-    @Column(nullable = false)
-    val checkTime: LocalDateTime,
+    var checkTime: LocalDateTime? = null,
 
     @Column(nullable = false)
     val status: Status
@@ -30,7 +29,7 @@ data class Attendance (
     constructor(): this(
         id = 0L,
         user = AuthUser(),
-        checkTime = LocalDateTime.now(),
+        checkTime = null,
         status = Status.NOT_ATTENDING
     )
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/NoAttendance.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/NoAttendance.kt
@@ -25,5 +25,8 @@ data class NoAttendance (
     val attendanceTime:LocalDateTime
 
 ) {
-    constructor() : this(0L, AuthUser(), LocalDateTime.now())
+    constructor() : this(
+        id = 0L,
+        student = AuthUser(),
+        attendanceTime = LocalDateTime.now())
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Status.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/attendance/Status.kt
@@ -1,5 +1,8 @@
 package com.apple.team_prometheus.domain.attendance
 
+import com.apple.team_prometheus.global.exception.ErrorCode
+import com.apple.team_prometheus.global.exception.Exceptions
+
 enum class Status {
     ATTENDED,
     NOT_ATTENDING;
@@ -8,7 +11,9 @@ enum class Status {
 
     fun changeStatus(): Status {
         return when (this) {
-            ATTENDED -> NOT_ATTENDING
+            ATTENDED -> throw Exceptions(
+                ErrorCode.ALREADY_ATTENDED
+            )
             NOT_ATTENDING -> ATTENDED
         }
     }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
@@ -6,8 +6,8 @@ import com.apple.team_prometheus.global.jwt.AccessToken
 class AuthLoginDto {
 
     data class Response(
-        var id: Long,
-        var token: AccessToken.Response
+        var name: String,
+        var accessToken: AccessToken.Response
     )
 
     data class Request (

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
@@ -34,7 +34,7 @@ data class AuthUser(
     @Column(nullable = false)
     val role: Role,
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = [CascadeType.ALL])
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
     var attendance: Attendance? = null,
 
     @OneToMany(fetch = FetchType.EAGER)

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthUser.kt
@@ -2,6 +2,7 @@ package com.apple.team_prometheus.domain.auth
 
 import com.apple.team_prometheus.domain.attendance.Attendance
 import com.apple.team_prometheus.domain.attendance.NoAttendance
+import com.apple.team_prometheus.domain.going.GoingApply
 import com.fasterxml.jackson.annotation.JsonIgnore
 import jakarta.persistence.*
 import java.time.LocalDate
@@ -28,17 +29,19 @@ data class AuthUser(
     @Column(nullable = false, name = "name")
     var name: String,
 
-    @Column(nullable = false)
-    var roomNum: Int,
+    var roomNum: Int? = null,
 
     @Column(nullable = false)
     val role: Role,
 
-    @OneToMany(fetch = FetchType.EAGER)
-    var attendance: List<Attendance>,
+    @OneToOne(fetch = FetchType.EAGER, cascade = [CascadeType.ALL])
+    var attendance: Attendance? = null,
 
     @OneToMany(fetch = FetchType.EAGER)
     var noAttendance: List<NoAttendance>,
+
+    @OneToMany(fetch = FetchType.EAGER)
+    var goingApply: List<GoingApply> = emptyList(),
 
     @Column(nullable = false, name = "birth_year")
     var birth: LocalDate,
@@ -57,8 +60,9 @@ data class AuthUser(
         name = "",
         roomNum = 0,
         role = Role.STUDENT,
-        attendance = emptyList(),
+        attendance = null,
         noAttendance = emptyList(),
+        goingApply = emptyList(),
         birth = LocalDate.now(),
         yearOfAdmission = Year.now(),
         isGraduate = false

--- a/src/main/kotlin/com/apple/team_prometheus/domain/going/GoingApply.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/going/GoingApply.kt
@@ -29,5 +29,12 @@ data class GoingApply(
     val content: String
 ) {
 
-    constructor() : this(0L, AuthUser(), false, LocalDate.now(), LocalDate.now(), "", "")
+    constructor() : this(
+        id = 0L,
+        user = AuthUser(),
+        going = false,
+        outDateTime = LocalDate.now(),
+        inDateTime = LocalDate.now(),
+        title = "",
+        content = "")
 }

--- a/src/main/kotlin/com/apple/team_prometheus/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/exception/ErrorCode.kt
@@ -7,7 +7,7 @@ enum class ErrorCode(val httpStatus: HttpStatus, val errorMessage: String) {
     // Status 400
     INVALID_REQUEST_ERROR(HttpStatus.BAD_REQUEST, "잘못된 요청값"),
     INVALID_DATE_ERROR(HttpStatus.BAD_REQUEST, "잘못된 날짜값"),
-
+    ALREADY_ATTENDED(HttpStatus.BAD_REQUEST, "이미 출석 체크한 유저입니다."),
 
     // Status 401
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰값"),
@@ -23,7 +23,7 @@ enum class ErrorCode(val httpStatus: HttpStatus, val errorMessage: String) {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없음"),
 
     // Status 409
-    DUPLICATED_ID(HttpStatus.CONFLICT, "이미 사용중인 아이디"),
+    DUPLICATED(HttpStatus.CONFLICT, "이미 있는 유저 정보"),
 
     // Status 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류")

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/AccessToken.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/AccessToken.kt
@@ -4,7 +4,7 @@ class AccessToken {
 
     data class Response (
         val result: String?,
-        val token: String?,
+        val accessToken: String?,
         val refreshToken: String?
     )
 

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenAuthenticationFilter.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/TokenAuthenticationFilter.kt
@@ -16,7 +16,8 @@ import java.io.IOException
 
 @Component
 class TokenAuthenticationFilter(
-    private val tokenProvider: TokenProvider
+    private val tokenProvider: TokenProvider,
+    private val jwtRepository: JwtRepository
 ) : OncePerRequestFilter() {
 
     @Throws(ServletException::class, IOException::class)
@@ -50,6 +51,13 @@ class TokenAuthenticationFilter(
         } catch (e: ExpiredJwtException) {
 
             println("TokenAuthenticationFilter: Expired Token - ${e.message}")
+
+            val claims = e.claims
+            val userId = claims["id"] as? Long
+            if (userId != null) {
+                jwtRepository.deleteById(userId)
+            }
+
             throw JwtException("Expired token, 토큰 기한 만료")
 
         } catch (e: SignatureException) {


### PR DESCRIPTION
### **🔹 작업 내용**

- 출석 체크에서 오류가 날 때 반환되는 에러를 커스텀 에러로 바꾸었습니다.
- RefreshToken이 만료가 될 시 삭제를 하는 로직을 구현하였습니다.

### **🔍 변경 사항 상세**

- **API 추가:**
    - 출석 체크 관련 커스텀 에러 구현
    - 출석 체크를 하는 도중 에러가 발생 시 커스텀 에러 반환
    - RefreshToken이 만료 시 삭제
- **기존 방식 vs 변경 후 방식:**
    - 기존에는 자바 내부에 있는 에러 반환 함수로 에러를 리턴하였지만 변경 후에는 직접 커스텀한 에러가 반환이 됩니다.
    - RefreshToken이 만료 시에도 DB에 남아있는데 이를 해결하기 위해 만료 시 삭제가 되도록 하였습니다.

### **📸 스크린샷 (UI 변경이 있을 경우)**

- 백엔드 작업이므로 해당사항 없음.

### **⚠️ 주의 사항 & 중점적으로 봐야 할 부분**

- **오류가 적절히 반환되는지 확인 필요**
- **JWT 토큰의 만료 시간 및 Refresh Token 관리 정책 검토 필요**
- **출석 체크 실패 시, 적절한 에러 메시지가 반환되는지 확인 (401 Unauthorized vs 400 Bad Request 등)**

### **🔗 관련 이슈**

- **Fixes** #19 #20 