### PR TITLE
🚀 [Feature] #13 - jwt토큰을 httpOnly쿠키에 담아서 반환

### DIFF
--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthLoginDto.kt
@@ -7,7 +7,7 @@ class AuthLoginDto {
 
     data class Response(
         var name: String,
-        var accessToken: AccessToken.Response
+        var token: AccessToken.Response
     )
 
     data class Request (

--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/AuthService.kt
@@ -113,10 +113,10 @@ class AuthService(
 
     // 리프레시 토큰으로 액세스 토큰 갱신 (회전 적용)
     @Transactional
-    fun refreshAccessToken(request: CreateAccessTokenByRefreshToken): AccessToken.Response {
+    fun refreshAccessToken(request: String): AccessToken.Response {
         try {
             // 1. 리프레시 토큰 검증
-            val claims = jwtProvider.getClaims(request.refreshToken)
+            val claims = jwtProvider.getClaims(request)
             if (claims["type"] != "Refresh") {
                 throw Exceptions(
                     errorCode = ErrorCode.INVALID_TOKEN
@@ -140,7 +140,7 @@ class AuthService(
                 }
 
             // 저장된 리프레시 토큰과 요청된 리프레시 토큰이 일치하는지 확인
-            if (storedToken.refreshToken != request.refreshToken) {
+            if (storedToken.refreshToken != request) {
                 throw Exceptions(
                     errorCode = ErrorCode.INVALID_TOKEN
                 )

--- a/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/security/SecurityConfig.kt
@@ -31,6 +31,7 @@ class SecurityConfig(
                     //.requestMatchers("/auth/join").hasRole("TEACHER")
                     .requestMatchers(
                         AntPathRequestMatcher("/api/going/**"),
+                        AntPathRequestMatcher("/api/attendance/no-attendance"),
                     ).hasRole("TEACHER")
                     .requestMatchers(
                         AntPathRequestMatcher("/auth/join"),


### PR DESCRIPTION
### **🔹 작업 내용**

- jwt토큰을 httpOnly쿠키에 담아서 반환하도록 변경하였습니다.

### **🔍 변경 사항 상세**

- **기존 방식 vs 변경 후 방식:**
    - 기존에는 jwt토큰을 그냥 반환해 주어서 보안상 매우 취약하였지만, httpOnly쿠키에 담아서 반환을 하여 안전하게 토큰 로그인을 할 수 있도록 변경하였습니다.

### **📸 스크린샷 (UI 변경이 있을 경우)**

- 백엔드 작업이므로 해당사항 없음.

### **⚠️ 주의 사항 & 중점적으로 봐야 할 부분**
- **쿠키값이 제대로 담겨있는지 체크**

### **🔗 관련 이슈**

- **Feature** #24
- **Related** #1  (로그인 API와 연동 필요)