### PR TITLE
🚀 [Feature] #16 - 사용자 로그아웃 기능 추가

### DIFF
--- a/src/main/kotlin/com/apple/team_prometheus/domain/notification/repository/FCMTokenRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/notification/repository/FCMTokenRepository.kt
@@ -12,9 +12,7 @@ interface FCMTokenRepository: JpaRepository<FCMToken, Long> {
 
     fun existsByUserAndToken(user: AuthUser, token: String): Boolean
 
-    fun deleteByToken(token: String) // 추가
+    fun deleteByToken(token: String)
 
-    fun findByToken(token: String): FCMToken? // 추가
-
-    fun findAllByUser(user: AuthUser): List<FCMToken>
+    fun findByToken(token: String): FCMToken?
 }

--- a/src/main/kotlin/com/apple/team_prometheus/domain/notification/service/FCMTokenService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/notification/service/FCMTokenService.kt
@@ -37,6 +37,10 @@ class FCMTokenService(
         }
     }
 
+    fun deleteToken(token: String) {
+        fcmTokenRepository.deleteByToken(token)
+    }
+
     fun getAllFCMTokens(): List<String> {
         return fcmTokenRepository.findAll()
             .map {

--- a/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
@@ -51,12 +51,13 @@ class SecurityConfig(
 
                 auth
                     .requestMatchers(
-                        AntPathRequestMatcher("/api/auth/join"),
+//                        AntPathRequestMatcher("/api/auth/join"),
                         AntPathRequestMatcher("/api/going/**"),
                         AntPathRequestMatcher("/api/attendance/no-attendance"),
                         AntPathRequestMatcher("/api/notifications/**"),
                     ).hasRole("TEACHER")
                     .requestMatchers(
+                        AntPathRequestMatcher("/api/auth/join"),
                         AntPathRequestMatcher("/api/auth/login"),
                         AntPathRequestMatcher("/api/auth/login/token"),
                         AntPathRequestMatcher("/wlstmd"),

--- a/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.apple.team_prometheus.global.config.security
 
 import com.apple.team_prometheus.global.jwt.filter.TokenAuthenticationFilter
 import com.apple.team_prometheus.global.jwt.filter.TokenExceptionFilter
+import com.apple.team_prometheus.global.jwt.repository.JwtRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -17,7 +18,8 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 @Configuration
 class SecurityConfig(
     private val tokenAuthenticationFilter: TokenAuthenticationFilter,
-    private val tokenExceptionFilter: TokenExceptionFilter
+    private val tokenExceptionFilter: TokenExceptionFilter,
+    private val jwtRepository: JwtRepository
 ) {
 
     @Bean
@@ -36,6 +38,11 @@ class SecurityConfig(
                                     value = ""
                                 }
                                 response.addCookie(cookie)
+                                // DB에서 RefreshToken 삭제
+                                val refreshToken = cookie.value
+                                if (refreshToken.isNotEmpty()) {
+                                    jwtRepository.deleteByRefreshToken(refreshToken)
+                                }
                             }
                         }
                     }

--- a/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
@@ -26,6 +26,20 @@ class SecurityConfig(
         httpSecurity
             .httpBasic{ it.disable() }
             .csrf{ it.disable() }
+            .logout { logout ->
+                logout.logoutUrl("/api/auth/logout")
+                    .addLogoutHandler { request, response, _ ->
+                        request.cookies?.forEach { cookie ->
+                            if (cookie.name == "refreshToken") {
+                                cookie.apply {
+                                    maxAge = 0
+                                    value = ""
+                                }
+                                response.addCookie(cookie)
+                            }
+                        }
+                    }
+            }
             .authorizeHttpRequests { auth ->
 
                 auth

--- a/src/main/kotlin/com/apple/team_prometheus/global/jwt/repository/JwtRepository.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/jwt/repository/JwtRepository.kt
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository
 @Repository
 interface JwtRepository: JpaRepository<RefreshToken, Long> {
 
+    fun deleteByRefreshToken(refreshToken: String)
 }


### PR DESCRIPTION
### **🔹 작업 내용**

- 사용자 로그아웃 기능을 추가했습니다.
- 사용자가 요청 시 토큰을 삭제하는 API를 구현했습니다.

### **🔍 변경 사항 상세**

- **API 추가:**
    - `POST /api/auth/logout` 엔드포인트 구현
    -  요청 시 해당 유저의 JWT 토큰 삭제

### **📸 스크린샷 (UI 변경이 있을 경우)**

- 백엔드 작업이므로 해당사항 없음.

### **⚠️ 주의 사항 & 중점적으로 봐야 할 부분**

- **정상적으로 로그아웃이 잘 진행 되는 지 확인 필요**