### PR TITLE
🚀 [Feature] #16 - 급식 정보 조회 시. 존재하는 정보가 없을 경우 에러 반환

### DIFF
--- a/src/main/kotlin/com/apple/team_prometheus/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/auth/service/AuthService.kt
@@ -43,6 +43,21 @@ class AuthService(
         joinDto: AuthJoinDto.Request
     ): AuthJoinDto.Response {
 
+        // 중복된 이름과 생년월일로 사용자 조회
+        val existingUser = authRepository.findByBirthYearAndName(
+            birth = LocalDate.parse(
+                joinDto.birth,
+                DateTimeFormatter.ofPattern("yyyy/MM/dd")
+            ),
+            name = joinDto.name
+        )
+
+        if (existingUser.isPresent) {
+            throw Exceptions(
+                errorCode = ErrorCode.DUPLICATED,
+            )
+        }
+
 
         val newUser = AuthUser(
            password = passwordEncoder.encode(joinDto.password),

--- a/src/main/kotlin/com/apple/team_prometheus/domain/meal/service/MealService.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/domain/meal/service/MealService.kt
@@ -1,6 +1,8 @@
 package com.apple.team_prometheus.domain.meal.service
 
 import com.apple.team_prometheus.domain.meal.dto.MealDto
+import com.apple.team_prometheus.global.exception.ErrorCode
+import com.apple.team_prometheus.global.exception.Exceptions
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -46,6 +48,12 @@ class MealService(
 
         val filteredResponse = response.mealServiceDietInfo.filter {
             !it.row.isNullOrEmpty()
+        }
+
+        if (filteredResponse.isEmpty()) {
+            throw Exceptions(
+                errorCode = ErrorCode.MEAL_NOT_FOUND,
+            )
         }
 
         return MealDto.Response(

--- a/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/config/security/SecurityConfig.kt
@@ -55,6 +55,7 @@ class SecurityConfig(
                         AntPathRequestMatcher("/api/going/**"),
                         AntPathRequestMatcher("/api/attendance/no-attendance"),
                         AntPathRequestMatcher("/api/notifications/**"),
+                        AntPathRequestMatcher("/api/auth/users"),
                     ).hasRole("TEACHER")
                     .requestMatchers(
                         AntPathRequestMatcher("/api/meals/daily"),

--- a/src/main/kotlin/com/apple/team_prometheus/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/apple/team_prometheus/global/exception/ErrorCode.kt
@@ -22,6 +22,7 @@ enum class ErrorCode(val httpStatus: HttpStatus, val errorMessage: String) {
     // Status 404
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없음"),
     GOING_NOT_FOUND(HttpStatus.NOT_FOUND, "신청한 유저를 찾을 수 없음"),
+    MEAL_NOT_FOUND(HttpStatus.NOT_FOUND, "급식 정보를 찾을 수 없음"),
 
     // Status 409
     DUPLICATED(HttpStatus.CONFLICT, "이미 있는 유저 정보"),


### PR DESCRIPTION
### **🔹 작업 내용**

- 급식 정보가 존재하지 않을 시 Exception을 반환하도록 하였습니다.
- 회원 가입 시 중복되는 정보가 있을 경우 Exception을 반환 하도록 설정하였습니다.
- GET /api/auth/users API를 TEACHER 권한을 가진 유저만 접속이 가능하도록 하였습니다.

### **🔍 변경 사항 상세**

- **Exception 추가:**
    - 급식 정보 미 조회 시 404 Error 반환
    - 사용자 로그인 정보 중복 시 409 Error 반환
- **기존 API 접근 vs 변경 후 API 접근:**
    - 기존에는 `GET /api/auth/users` API 접근 시 어떤 유저가 접근하여도 403을 반환
    - 변경 후 TEACHER 권한을 가진 유저라면 접근이 가능